### PR TITLE
Added changes into Diana_Hook

### DIFF
--- a/src/diana_core/diana_core/diana_patchers/diana_ultimate_patcher.h
+++ b/src/diana_core/diana_core/diana_patchers/diana_ultimate_patcher.h
@@ -36,6 +36,7 @@ void DianaHook_TargetMemoryProvider_Init(DianaHook_TargetMemoryProvider * pDiana
 
 #define DIANA_HOOK_CUSTOM_OPTION_PUT_FAR_JMP              1
 #define DIANA_HOOK_CUSTOM_OPTION_DONT_FOLLOW_JUMPS        2
+#define DIANA_HOOK_CUSTOM_OPTION_PUT_FAR_JMP_SHORT        4
 
 typedef struct _DianaHook_CustomOptions
 {


### PR DESCRIPTION
Начал девтестить и столкнулся с проблемой, что на Win10, которая на виртуалке, функции ntdll имеют размер всего 11 байт. Соответственно farJump, который используется для джампа на обработчик хука не ставится, так как его размер 14 байт.
Память которая выделяется для обработчика хука всегда ниже 0xffffffff, поэтому мне достаточно запушить этот адрес на стек и сделать ret.
Я реализовал небольшой фикс с добавлением кастомной опции для подобного кейса.
Проверял, работает отлично.